### PR TITLE
Fix opening app for high-phone 2.0

### DIFF
--- a/calculator.css
+++ b/calculator.css
@@ -1,5 +1,4 @@
 .calculator {
-    display: none;
     position: absolute;
     top: 0;
     width: 100%;


### PR DESCRIPTION
With the new version of high-phone (currently in testing), the display: none; in the css must be removed